### PR TITLE
Update filesystem.mdx to fix typo

### DIFF
--- a/website/content/docs/internals/filesystem.mdx
+++ b/website/content/docs/internals/filesystem.mdx
@@ -66,7 +66,7 @@ allocation directory like the one below.
 
   - **«taskname»/secrets/**: This directory is the location provided to the task as
     `NOMAD_SECRETS_DIR`. The contents of files in this directory cannot be read
-    the the `nomad alloc fs` command. It can be used to store secret data that
+    by the `nomad alloc fs` command. It can be used to store secret data that
     should not be visible outside the task.
 
   - **«taskname»/tmp/**: A temporary directory used as scratch space by task drivers.


### PR DESCRIPTION
Change:
 - directory cannot be read the the nomad alloc fs command
to
- directory cannot be read by the nomad alloc fs command